### PR TITLE
Scheme для AJAX post запроса

### DIFF
--- a/core/components/ajaxsnippet/elements/snippets/snippet.ajaxsnippet.php
+++ b/core/components/ajaxsnippet/elements/snippets/snippet.ajaxsnippet.php
@@ -15,9 +15,10 @@ $spinner = 'data:image/gif;base64,R0lGODlhQABAAKUAAAQCBISChMTCxERCRKSipOTi5GRiZC
 if (!empty($wrapper)) {$wrapper = $modx->getChunk($wrapper);}
 if (empty($as_mode)) {$as_mode = 'OnLoad';}
 if (empty($as_target)) {$as_target = '#'.$key;}
+if (empty($scheme)) {$scheme = 'full';}
 
 $script = '
-$.post("'.$modx->context->makeUrl($modx->resource->id, '', 'full').'", {as_action: "'.$key.'"}, function(response) {
+$.post("'.$modx->context->makeUrl($modx->resource->id, '', $scheme).'", {as_action: "'.$key.'"}, function(response) {
 	if (typeof response.output !== "undefined") {
 		$("'.$as_target.'").html(response.output);
 		spinner.remove();


### PR DESCRIPTION
Возможность указать схему генерации URL при post запросе AJAX.
(необходимо для корректной работы сайта при доступности и по http и по https - лучше указывать относительную ссылку вида `/uri`)